### PR TITLE
Added (http) method name to md and pdf exports

### DIFF
--- a/lib/exporter.js
+++ b/lib/exporter.js
@@ -50,7 +50,10 @@ const appendMarkdownCode = content => (item, isRequest) => {
 }
 
 const generateMarkdownRequest = item => {
-    var requestMarkdown = '## `Request` ' + item.name;
+    var itemName = item.name;
+    var method = item.request.method;
+
+    var requestMarkdown = `## \`[${method}]\` ${itemName}`;
     if (item.request.description !== undefined) {
         requestMarkdown += '\n' + downgradeHeadings(item.request.description.content);
     }


### PR DESCRIPTION
Hi there,
I've modified the `.md` and `.pdf` exports. Before the exports just said "Request" before each request name. I've replaced the "Request" with the method type (aka, `POST`. `GET`, `PUT`, etc..)

I've included the new and old exports. Note that new exports have a _new_ prefix, and old ones have and _old_ prefix 

[new PDF export.pdf](https://github.com/ile2807/postman-collection-tools/files/7235036/newPdf.pdf)
[new MD export.md](https://github.com/ile2807/postman-collection-tools/files/7235035/new.md)

[old MD export.md](https://github.com/ile2807/postman-collection-tools/files/7235033/old.md)
[old PDF export.pdf](https://github.com/ile2807/postman-collection-tools/files/7235034/oldPdf.pdf)

 